### PR TITLE
Install docker using amazon-linux-extras

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.2.1 (2023-01-16)
+--------------------------
+Install docker using amazon-linux-extras (#7)
+
 Version 0.2.0 (2023-06-22)
 --------------------------
 Remove deprecated tags input for asg resource (#4)

--- a/templates/user-data.sh.tmpl
+++ b/templates/user-data.sh.tmpl
@@ -7,7 +7,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 # -----------------------------------------------------------------------------
 
 function install_docker_ce() {
-  sudo yum install -y docker-20.10.4-1.amzn2
+  sudo amazon-linux-extras install docker=stable
   sudo systemctl enable docker
   sudo systemctl start docker
   sudo usermod -a -G docker ec2-user


### PR DESCRIPTION
The latest AMI breaks when we import terraform, this PR is to fix that issue:


```[ec2-user@ip-172-31-13-81 ~]$ sudo cat /var/log/user-data.log
+ install_docker_ce
+ sudo yum install -y docker-20.10.4-1.amzn2
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Resolving Dependencies
--> Running transaction check
---> Package docker.x86_64 0:20.10.4-1.amzn2 will be installed
--> Processing Dependency: containerd >= 1.3.2 for package: docker-20.10.4-1.amzn2.x86_64
--> Processing Dependency: libcgroup >= 0.40.rc1-5.15 for package: docker-20.10.4-1.amzn2.x86_64
--> Processing Dependency: runc >= 1.0.0 for package: docker-20.10.4-1.amzn2.x86_64
--> Processing Dependency: pigz for package: docker-20.10.4-1.amzn2.x86_64
--> Running transaction check
---> Package containerd.x86_64 0:1.7.2-1.amzn2.0.1 will be installed
---> Package libcgroup.x86_64 0:0.41-21.amzn2 will be installed
---> Package pigz.x86_64 0:2.3.4-1.amzn2.0.1 will be installed
---> Package runc.x86_64 0:1.1.7-4.amzn2 will be installed
--> Processing Conflict: libseccomp-2.5.2-1.amzn2.0.1.x86_64 conflicts docker < 20.10.25
--> Finished Dependency Resolution
Error: libseccomp conflicts with docker-20.10.4-1.amzn2.x86_64
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest```

