### PR TITLE
feat: add DNF install docker retry logic

### DIFF
--- a/templates/user-data.sh.tmpl
+++ b/templates/user-data.sh.tmpl
@@ -7,7 +7,28 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 # -----------------------------------------------------------------------------
 
 function install_docker_ce() {
-  sudo dnf install docker -y
+  local max_attempts=10
+  local sleep_time=5
+  local __attempt_num=1
+  local __success=false
+
+  while [ $__success = false ] && [ $__attempt_num -le $max_attempts ]; do
+    echo "Attempting dnf install docker (attempt $__attempt_num of $max_attempts)..."
+    if sudo dnf install docker -y; then
+      echo "dnf install docker succeeded"
+      __success=true
+    else
+      echo "Attempt $__attempt_num failed. Sleeping for $sleep_time seconds and trying again..."
+      sleep $sleep_time
+      ((__attempt_num++))
+    fi
+  done
+
+  if [ $__success = false ]; then
+    echo "Failed to install docker after $max_attempts attempts"
+    exit 1
+  fi
+
   sudo systemctl start docker
   sudo systemctl enable docker
   sudo usermod -a -G docker ec2-user


### PR DESCRIPTION
There is a race condition in `install_docker_ce()`, e.g., in cases when the SSM Agent is being installed. 
```
RPM: error: can't create transaction lock on /var/lib/rpm/.rpm.lock (Resource temporarily unavailable)
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: Could not run transaction.
```
When this happens, the instance simply fails to start, so this PR is adding retry logic into `install_docker_ce()`
I have chosen retry logic, instead of checking if the lockfile exists, as there will still be a small rece condition between checking for the lockfile and running dnf install, and also other errors can occur, e.g.:
```
[Errno 2] No such file or directory: '/var/cache/dnf/amazonlinux-6d07f88cfac75807/packages/container-selinux-2.245.0-1.amzn2023.noarch.rpm'
```
The ultimate solution would be to use AMI with Docker already installed, but that comes with the complexity of maintaining custom AMI

With retry logic, it looks like:
```
+ install_docker_ce
+ local max_attempts=10
+ local sleep_time=5
+ local __attempt_num=1
+ local __success=false
+ '[' false = false ']'
+ '[' 1 -le 10 ']'
+ echo 'Attempting dnf install docker (attempt 1 of 10)...'
Attempting dnf install docker (attempt 1 of 10)...
+ sudo dnf install docker -y
...
RPM: error: can't create transaction lock on /var/lib/rpm/.rpm.lock (Resource temporarily unavailable)
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: Could not run transaction.
+ echo 'Attempt 1 failed. Sleeping for 5 seconds and trying again...'
Attempt 1 failed. Sleeping for 5 seconds and trying again...
+ sleep 5
+ (( __attempt_num++ ))
+ '[' false = false ']'
+ '[' 2 -le 10 ']'
+ echo 'Attempting dnf install docker (attempt 2 of 10)...'
Attempting dnf install docker (attempt 2 of 10)...
+ sudo dnf install docker -y
Waiting for process with pid 2288 to finish.
Last metadata expiration check: 0:00:01 ago on Thu Mar 12 18:12:56 2026.
...
Installed:
  container-selinux-4:2.245.0-1.amzn2023.noarch                                 
  containerd-2.2.1-1.amzn2023.0.1.x86_64                                        
  docker-25.0.14-1.amzn2023.0.2.x86_64                                          
  iptables-libs-1.8.8-3.amzn2023.0.2.x86_64                                     
  iptables-nft-1.8.8-3.amzn2023.0.2.x86_64                                      
  libcgroup-3.0-1.amzn2023.0.1.x86_64                                           
  libnetfilter_conntrack-1.0.8-2.amzn2023.0.2.x86_64                            
  libnfnetlink-1.0.1-19.amzn2023.0.2.x86_64                                     
  libnftnl-1.2.2-2.amzn2023.0.2.x86_64                                          
  pigz-2.5-1.amzn2023.0.3.x86_64                                                
  runc-1.3.4-1.amzn2023.0.2.x86_64                                              

Complete!
+ echo 'dnf install docker succeeded'
dnf install docker succeeded
+ __success=true
+ '[' true = false ']'
+ '[' true = false ']'
+ sudo systemctl start docker
...
```